### PR TITLE
fix: Add safe directory config to commit operations test workflow

### DIFF
--- a/.github/workflows/test.core.action.commit_operations.yml
+++ b/.github/workflows/test.core.action.commit_operations.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           git config --global user.email "test@github.com"
           git config --global user.name "Test User"
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           
           # Initialize a clean environment
           git checkout -b test-commits || true


### PR DESCRIPTION
Resolves git permission error when adding files in GitHub Actions:
- Added git config --add safe.directory to mark workspace as safe
- Fixes 'insufficient permission for adding an object' error
