### PR TITLE
fix: Add current directory to safe directories in commit operations

### DIFF
--- a/actions/core/commit_operations/main.py
+++ b/actions/core/commit_operations/main.py
@@ -30,8 +30,9 @@ class GitCommitOperations:
             # Check if git is available
             subprocess.check_output(['git', '--version'], stderr=subprocess.STDOUT)
             
-            # Configure safe directory
+            # Configure safe directory - add both common GitHub Actions paths
             subprocess.check_call(['git', 'config', '--global', '--add', 'safe.directory', '/github/workspace'])
+            subprocess.check_call(['git', 'config', '--global', '--add', 'safe.directory', os.getcwd()])
             
             # Set default Git identity if not configured
             try:


### PR DESCRIPTION
The action was only adding /github/workspace but also needs to add
the current working directory to handle different mount points in
Docker containers. This resolves the git permission error when
running in GitHub Actions.
