### PR TITLE
feat: Configure Dependabot to target staging branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,33 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  target-branch: "staging"
+  # Unfortunately, Dependabot doesn't support custom prefixes like "develop/patch-"
+  # It uses fixed patterns like "dependabot/github_actions/package-version"
+  # However, we can use labels and assignees to help manage these PRs
+  labels:
+    - "dependencies"
+    - "github-actions"
+    - "develop"
+  assignees:
+    - "mattbuske"
 - package-ecosystem: pip
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  target-branch: "staging"
+  labels:
+    - "dependencies"
+    - "python"
+    - "develop"
+  assignees:
+    - "mattbuske"
 #- package-ecosystem: gitsubmodule
 #  directory: "/"
 #  schedule:
 #    interval: daily
 #  open-pull-requests-limit: 10
+#  target-branch: "staging"
+#  pull-request-branch-name:
+#    separator: "/"


### PR DESCRIPTION
Updated Dependabot configuration to align with branching strategy:
- Changed target-branch from main to staging for all ecosystems
- Added labels to identify develop-related dependency updates
- Added assignee for automatic assignment

Note: Dependabot doesn't support custom branch name prefixes like 'develop/patch-'.
It will still create branches with pattern 'dependabot/<ecosystem>/<package>-<version>'
but now these PRs will target staging instead of main.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
