### PR TITLE
Add update_changelog unit tests

### DIFF
--- a/.github/workflows/test.framework.yml
+++ b/.github/workflows/test.framework.yml
@@ -24,6 +24,7 @@ jobs:
           - actions/core/version_calculator
           - actions/core/version_updater
           - actions/core/manage_release
+          - actions/composite/update_changelog
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/actions/composite/update_changelog/pytest.ini
+++ b/actions/composite/update_changelog/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+markers =
+    unit: Unit tests
+    integration: Integration tests
+    changelog: Tests for changelog operations
+
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*

--- a/actions/composite/update_changelog/tests/conftest.py
+++ b/actions/composite/update_changelog/tests/conftest.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+import subprocess
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def mock_subprocess():
+    """Mock subprocess for compatibility."""
+    with patch('subprocess.check_call') as mock_check_call, \
+         patch('subprocess.check_output') as mock_check_output, \
+         patch('subprocess.run') as mock_run:
+        mock_check_call.return_value = 0
+        mock_check_output.return_value = "mocked output"
+        mock_run_instance = MagicMock()
+        mock_run_instance.stdout = "mocked stdout"
+        mock_run_instance.stderr = ""
+        mock_run_instance.returncode = 0
+        mock_run.return_value = mock_run_instance
+        yield {
+            'check_call': mock_check_call,
+            'check_output': mock_check_output,
+            'run': mock_run
+        }
+
+
+@pytest.fixture
+def mock_git_env():
+    """Set environment variables expected by the action."""
+    env_vars = {
+        'GITHUB_REPOSITORY': 'test-org/test-repo',
+        'GITHUB_TOKEN': 'mock-token',
+        'GITHUB_WORKSPACE': '/github/workspace',
+        'GITHUB_OUTPUT': '/tmp/github_output'
+    }
+    original = os.environ.copy()
+    for k, v in env_vars.items():
+        os.environ[k] = v
+    with open(env_vars['GITHUB_OUTPUT'], 'w') as fh:
+        fh.write('')
+    yield env_vars
+    os.environ.clear()
+    os.environ.update(original)
+    if os.path.exists(env_vars['GITHUB_OUTPUT']):
+        os.remove(env_vars['GITHUB_OUTPUT'])

--- a/actions/composite/update_changelog/tests/test_update_changelog.py
+++ b/actions/composite/update_changelog/tests/test_update_changelog.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Add path to import update_changelog module
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import update_changelog as uc
+
+class FixedDateTime:
+    """Helper datetime class returning a fixed date."""
+    @classmethod
+    def now(cls):
+        return cls.fake_now
+
+    @staticmethod
+    def strftime(fmt):
+        return FixedDateTime.fake_now.strftime(fmt)
+
+FixedDateTime.fake_now = __import__('datetime').datetime(2025, 1, 1)
+
+@pytest.mark.unit
+@pytest.mark.changelog
+def test_unreleased_mode(tmp_path, monkeypatch, mock_git_env):
+    changelog = tmp_path / 'CHANGELOG.md'
+    changelog.write_text("# Changelog\nNotes\n\n## **[(01/01/2024) - v0.1.0](https://example.com)**\n- old\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(uc, 'datetime', FixedDateTime)
+
+    content = '### Added\n- New stuff'
+    uc.update_changelog(content, 'unreleased', 'v0.2.0')
+
+    text = changelog.read_text()
+    assert f"## **{FixedDateTime.fake_now.strftime('%m/%d/%Y')} - v0.2.0 Unreleased**" in text
+    assert '### Added' in text
+    # New section should appear before previous release line
+    assert text.index('Unreleased') < text.index('v0.1.0')
+
+@pytest.mark.unit
+@pytest.mark.changelog
+def test_release_mode(tmp_path, monkeypatch, mock_git_env):
+    date = FixedDateTime.fake_now.strftime('%m/%d/%Y')
+    unreleased = f"## **{date} - v0.2.0 Unreleased**"
+    changelog = tmp_path / 'CHANGELOG.md'
+    changelog.write_text(f"# Changelog\nInfo\n\n{unreleased}\nChanges here\n\n## **[(01/01/2024) - v0.1.0](https://example.com)**\n- old\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(uc, 'datetime', FixedDateTime)
+
+    uc.update_changelog('Changes here', 'release', 'v0.2.0')
+    text = changelog.read_text()
+    expected_link = f"## **[({date}) - v0.2.0](https://github.com/{mock_git_env['GITHUB_REPOSITORY']}/releases/tag/v0.2.0)**"
+    assert unreleased not in text
+    assert expected_link in text
+    # Ensure previous release still present
+    assert 'v0.1.0' in text


### PR DESCRIPTION
## Summary
- add pytest configuration and tests for composite update_changelog action
- wire action into the CI test matrix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851d1032b688321bfd276b891a4e9ad